### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: bionic
+language: minimal
+services: docker
+matrix:
+  include:
+    - name: fedora30
+      env:
+        - BASE_IMAGE=fedora:30
+    - name: fedora31
+      env:
+        - BASE_IMAGE=fedora:31
+    - name: python2
+      language: python
+      python: '2.7'
+      install:
+      script: python fedora_active_user.py --help
+  allow_failures:
+  fast_finish: true
+install:
+  - |
+    travis_retry docker build --rm -t fedora-active-user \
+      -f Dockerfile-fedora \
+      --build-arg BASE_IMAGE=${BASE_IMAGE} \
+      .
+script:
+  - docker run --rm -t fedora-active-user python3 fedora_active_user.py --help

--- a/Dockerfile-fedora
+++ b/Dockerfile-fedora
@@ -1,0 +1,12 @@
+ARG BASE_IMAGE=fedora:30
+FROM ${BASE_IMAGE}
+
+RUN dnf -y upgrade \
+  && dnf -y install \
+  --setopt=tsflags=nodocs \
+  # Runtime dependency
+  python3 \
+  && dnf clean all
+
+WORKDIR /work
+COPY . .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 fedora-active-user
 ==================
 
+[![Build Status](https://travis-ci.org/pypingou/fedora-active-user.svg?branch=master)](https://travis-ci.org/pypingou/fedora-active-user)
+
 This script generates a small report of the recent activity
 of a fellow Fedora contributor using either his FAS login
 or his email address.


### PR DESCRIPTION
This PR is to add 2 commits on https://github.com/pypingou/fedora-active-user/pull/13 .

1st commit is to run fedora-active-user without fedora-cert on Fedora 30 and Python3.
https://github.com/pypingou/fedora-active-user/pull/13#issuecomment-552223122

2nd commit is for a suggestion to enable Travis CI.

Here is the result of my forked repository.
https://travis-ci.org/junaruga/fedora-active-user/builds/610034248

Here is the modified `README.md` to add the build status badge for this repository.
https://github.com/junaruga/fedora-active-user/blob/feature/ci-py3-on-didier13150-master/README.md

As an initial CI, there are just 2 cases Fedora 30 and Fedora 31 with Python3.
I think it is still good as an initial CI setting.

Before merging this PR, please enable this repository's Travis if you are interested in it.
https://travis-ci.org/pypingou/fedora-active-user
