### PR TITLE
Fix Bodhi check

### DIFF
--- a/fedora_active_user.py
+++ b/fedora_active_user.py
@@ -69,7 +69,7 @@ def _get_bodhi_history(username):
 
     :arg username, the fas username whose action is searched.
     """
-    from fedora.client.bodhi import BodhiClient
+    from bodhi.client.bindings import BodhiClient
     bodhiclient = BodhiClient("https://bodhi.fedoraproject.org/")
 
     log.debug('Querying Bodhi for user: {0}'.format(username))


### PR DESCRIPTION
The Bodhi client moved from `fedora.client` to `bodhi.client.bindings`,
and the former is removed as of this commit:

https://github.com/fedora-infra/python-fedora/commit/ad1e87c04aca6860e9273039a3a11bfd483ad56d#diff-f260ce8db4a44fd0a5d8a8d4ebf83dfb63eb5ff7c48d0880f7abe3850e3322ea

Switch to importing from `bodhi.client.bindings`.

```
src/fedora/fedora-active-user on  fix-bodhi [!] via 🐍 v3.9.0
✦ ❯ python3 fedora_active_user.py --user salimma --nobz --nofedmsg --nokoji --nolists
FAS username: salimma
FAS password for salimma:

Last login in FAS:
   salimma 2021-01-08

Last package update on bodhi:
   2021-01-02 02:04:10 on package fb303-0-0.1.20201228git7700913.fc33 fbthrift-2020.12.28.00-1.fc33 fbzmq-2020.12.28.00-1.fc33 fizz-2020.12.28.00-1.fc33 folly-2020.12.28.00-1.fc33 wangle-2020.12.28.00-1.fc33 watchman-2020.12.28.00-1.fc33
```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypingou/fedora-active-user/19)
<!-- Reviewable:end -->
