### PR TITLE
Fix an exception when there's nothing in mailing lists

### DIFF
--- a/fedora_active_user.py
+++ b/fedora_active_user.py
@@ -232,7 +232,7 @@ def _get_last_email_list(email):
     data = json.loads(stream.read())
     stream.close()
     if not data["count"]:
-        print("   No activity found on %s" % mailinglist)
+        print("   No activity found on Fedora mailing lists")
     else:
         for entry in data["results"]:
             print(


### PR DESCRIPTION
NameError: name 'mailinglist' is not defined